### PR TITLE
Fixes #77. Tests were failing for non-UTC timezones as the cached DateFo...

### DIFF
--- a/cougar-framework/cougar-util/src/main/java/com/betfair/cougar/logging/records/EventLogRecord.java
+++ b/cougar-framework/cougar-util/src/main/java/com/betfair/cougar/logging/records/EventLogRecord.java
@@ -21,6 +21,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.TimeZone;
 import java.util.logging.Level;
 
 import com.betfair.cougar.api.LoggableEvent;
@@ -93,7 +94,9 @@ public final class EventLogRecord extends CougarLogRecord {
 
     private DateFormat getDateFormatter() {
         if (dateFormatter.get() == null) {
-            dateFormatter.set(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS"));
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+            dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+            dateFormatter.set(dateFormat);
         }
         return dateFormatter.get();
     }

--- a/cougar-framework/cougar-util/src/test/java/com/betfair/cougar/logging/records/EventLogRecordTest.java
+++ b/cougar-framework/cougar-util/src/test/java/com/betfair/cougar/logging/records/EventLogRecordTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.TimeZone;
 
 import com.betfair.cougar.api.LoggableEvent;
 import org.junit.Before;
@@ -38,6 +39,7 @@ public class EventLogRecordTest {
     public void setup() {
         mle = new MyLoggableEvent();
         elr = new EventLogRecord(mle, null);
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     }
 
     @Test
@@ -73,6 +75,7 @@ public class EventLogRecordTest {
     @Test
     public void testDate() throws Exception {
         SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
 
         Object[] things = new Object[1];
         things[0] = sdf.parse("01/12/1970");


### PR DESCRIPTION
...rmat was using a SimpleDateFormat with the default JVM timezone and the tests were enforcing UTC timezone. As Cougar officially only supports UTC we can/should make sure the SimpleDateFormat is using UTC timezone.
