### PR TITLE
Fixes #76. By using Maven's recommended ${java.home} property instead of...

### DIFF
--- a/cougar-test/cougar-client-code-tests/pom.xml
+++ b/cougar-test/cougar-client-code-tests/pom.xml
@@ -124,7 +124,7 @@
             <groupId>com.sun</groupId>
             <artifactId>tools</artifactId>
             <scope>system</scope>
-            <systemPath>${env.JAVA_HOME}/lib/tools.jar</systemPath>
+            <systemPath>${java.home}/../lib/tools.jar</systemPath>
             <version>${java.version}</version>
         </dependency>
 

--- a/cougar-test/cougar-test-utils/pom.xml
+++ b/cougar-test/cougar-test-utils/pom.xml
@@ -44,7 +44,7 @@
 			<groupId>com.sun</groupId>
 			<artifactId>tools</artifactId>
 			<scope>system</scope>
-			<systemPath>${env.JAVA_HOME}/lib/tools.jar</systemPath>
+			<systemPath>${java.home}/../lib/tools.jar</systemPath>
             <version>${java.version}</version>
 		</dependency>
 


### PR DESCRIPTION
... ${env.JAVA_HOME} we make sure it is available in all environments.
